### PR TITLE
MinionModel + resulting API changes

### DIFF
--- a/Models/ItemModel.cs
+++ b/Models/ItemModel.cs
@@ -36,19 +36,14 @@ namespace SummonersAssociation.Models
 		public byte SummonCount { get; set; }
 
 		/// <summary>
-		/// How many minion slots the weapon "creates" on use, hardcoded for some vanilla items, rest assumes SlotsNeeded
+		/// How many minion slots the weapon "creates" on use
 		/// </summary>
-		public float SlotsFilledPerUse => SummonersAssociation.SlotsFilledPerUse.TryGetValue(ItemType, out float value) ? value : SlotsNeeded;
+		public float SlotsFilledPerUse => ItemType > -1 && ItemType < ItemLoader.ItemCount ? ItemID.Sets.StaffMinionSlotsRequired[ItemType] : 1;
 
 		/// <summary>
 		///If this ItemModel corresponds to an item in the players inventory
 		/// </summary>
 		public bool Active { get; set; }
-
-		/// <summary>
-		///How many free minion slots this weapon needs/replaces
-		/// </summary>
-		public byte SlotsNeeded => ItemType > -1 && ItemType < ItemLoader.ItemCount ? (byte)ItemID.Sets.StaffMinionSlotsRequired[ItemType] : (byte)1;
 
 		/// <summary>
 		/// Default constructor. Used in Load

--- a/Models/MinionModel.cs
+++ b/Models/MinionModel.cs
@@ -1,59 +1,61 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Terraria;
+using Terraria.ModLoader;
 
 namespace SummonersAssociation.Models
 {
 	public class MinionModel
 	{
-		public int ItemID { get; private set; }
-		public int BuffID { get; private set; }
-		public List<int> ProjectileIDs { get; private set; }
-		public List<float> Slots { get; private set; }
+		public int ItemID { get; init; }
+		public int BuffID { get; init; }
 
-		public override string ToString() => Lang.GetItemNameValue(ItemID);
+		public List<ProjModel> ProjData { get; init; }
 
-		public MinionModel(int itemID, int buffID, int projectileID) : this(itemID, buffID, new List<int> { projectileID }, null) {
+		public override string ToString() => ItemID < Terraria.ID.ItemID.Count ? Lang.GetItemNameValue(ItemID) : ItemLoader.GetItem(ItemID).DisplayName.ToString();
 
-		}
-
-		public MinionModel(int itemID, int buffID, int projectileID, float slot) : this(itemID, buffID, new List<int> { projectileID }, new List<float> { slot }) {
+		// The most basic constructor (no optional values)
+		public MinionModel(int itemID, int buffID, int projectileID) : this(itemID, buffID, ProjModel.FromProjID(projectileID)) {
 
 		}
 
-		public MinionModel(int itemID, int buffID, List<int> projectileIDs, List<float> slots = null) {
+		// The second-most basic constructor (no optional values)
+		public MinionModel(int itemID, int buffID, List<int> projectileIDs) : this(itemID, buffID, GetProjDataFromProjIDs(projectileIDs)) {
+
+		}
+
+		// Main constructor (convenience)
+		public MinionModel(int itemID, int buffID, ProjModel projModel) : this(itemID, buffID, new List<ProjModel> { projModel }) {
+
+		}
+
+		// Main constructor
+		public MinionModel(int itemID, int buffID, List<ProjModel> projData) {
 			ItemID = itemID;
 			BuffID = buffID;
-			ProjectileIDs = projectileIDs;
-			Slots = slots ?? GetSlotsPerProjectile();
+			ProjData = projData;
 		}
 
 		/// <summary>
 		/// Copy constructor
 		/// </summary>
-		/// <param name="other">MinionModel to copy</param>
+		/// <param name="other">To copy</param>
 		public MinionModel(MinionModel other) {
 			ItemID = other.ItemID;
 			BuffID = other.BuffID;
-			ProjectileIDs = other.ProjectileIDs;
-			Slots = other.Slots;
+			ProjData = other.ProjData;
 		}
 
-		private List<float> GetSlotsPerProjectile() {
-			var slots = new List<float>();
-			foreach (int type in ProjectileIDs) {
-				try {
-					var proj = new Projectile();
-					proj.SetDefaults(type);
-					slots.Add(proj.minionSlots);
-				}
-				catch {
-					// In case it gets called before PostSetupContent for whatever reason, default to 1
-					slots.Add(1f);
-				}
+		internal static List<ProjModel> GetProjDataFromProjIDs(List<int> projIDs) {
+			var list = new List<ProjModel>();
+			foreach (int type in projIDs) {
+				list.Add(ProjModel.FromProjID(type));
 			}
-			return slots;
+			return list;
 		}
+
+		public bool ContainsProjID(int projID) => ProjData.Any(d => d.ProjID == projID);
 
 		internal Dictionary<string, object> ConvertToDictionary(Version GetSupportedMinionsAPIVersion) {
 			// We may want to allow different returns based on api version.
@@ -61,8 +63,7 @@ namespace SummonersAssociation.Models
 			var dict = new Dictionary<string, object> {
 				{ "ItemID", ItemID },
 				{ "BuffID", BuffID },
-				{ "ProjectileIDs", ProjectileIDs },
-				{ "Slots", Slots },
+				{ "ProjData", ProjData.Select(d => d.ConvertToDictionary(GetSupportedMinionsAPIVersion)).ToList() },
 			};
 
 			return dict;

--- a/Models/MinionModel.cs
+++ b/Models/MinionModel.cs
@@ -44,7 +44,7 @@ namespace SummonersAssociation.Models
 		public MinionModel(MinionModel other) {
 			ItemID = other.ItemID;
 			BuffID = other.BuffID;
-			ProjData = other.ProjData;
+			ProjData = new List<ProjModel>(other.ProjData);
 		}
 
 		internal static List<ProjModel> GetProjDataFromProjIDs(List<int> projIDs) {

--- a/Models/ProjModel.cs
+++ b/Models/ProjModel.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using Terraria;
+using Terraria.ID;
+using Terraria.ModLoader;
+
+namespace SummonersAssociation.Models
+{
+	// When expanding this, add handlers for the new data to the following:
+	// * ProjModel.ConvertToDictionary
+	// * ProjModel.FromDictionary
+	// * SummonersAssociationIntegration.MinionModel.FromDictionary (in SummonersAssociationIntegrationExample.cs)
+	// * ProjModel.FromProjID (if needed)
+	/// <summary>
+	/// Contains the projectile (ID) and any optional associated information
+	/// </summary>
+	/// <param name="ProjID">Mandatory</param>
+	/// <param name="Slot">Optional</param>
+	public record struct ProjModel(int ProjID, float Slot = 1f)
+	{
+		public override string ToString() => (ProjID < ProjectileID.Count ? Lang.GetProjectileName(ProjID) : ProjectileLoader.GetProjectile(ProjID).DisplayName).ToString();
+
+		internal Dictionary<string, object> ConvertToDictionary(Version GetSupportedMinionsAPIVersion) {
+			// We may want to allow different returns based on api version.
+			//if (GetSupportedMinionsDictionaryAPIVersion == new Version(0, 4, 7)) {
+			var dict = new Dictionary<string, object> {
+				{ "ProjID", ProjID },
+				{ "Slot", Slot },
+			};
+
+			return dict;
+		}
+
+		internal static ProjModel FromDictionary(Dictionary<string, object> dict, string error_itemMsg = null) {
+			// Mandatory ProjID
+			string projIDKey = "ProjID";
+			if (!dict.TryGetValue(projIDKey, out object o_ProjID)) {
+				string errorMsg = $"{nameof(ProjModel)} entry does not contain '{projIDKey}' key";
+				if (error_itemMsg != null)
+					throw new Exception(errorMsg + error_itemMsg);
+				else
+					throw new Exception(errorMsg);
+			}
+			int projID = Convert.ToInt32(o_ProjID);
+
+			// Optional rest
+			if (dict.TryGetValue("Slot", out object o_Slot)) {
+				float slot = Convert.ToSingle(o_Slot);
+				return new ProjModel(projID, slot);
+			}
+			else {
+				// Fall back to the most basic constructor
+				return FromProjID(projID);
+			}
+		}
+
+		internal static ProjModel FromProjID(int projID) {
+			try {
+				var proj = new Projectile();
+				proj.SetDefaults(projID);
+				return new ProjModel(projID, proj.minionSlots);
+			}
+			catch {
+				// In case it gets called before PostSetupContent for whatever reason, default to sensible values
+				return new ProjModel(projID);
+			}
+		}
+	}
+}

--- a/SummonersAssociation.cs
+++ b/SummonersAssociation.cs
@@ -13,10 +13,6 @@ namespace SummonersAssociation
 	public class SummonersAssociation : Mod
 	{
 		internal static List<MinionModel> SupportedMinions;
-		/// <summary>
-		/// Special weapons that summon a non-1f amount of minions on use
-		/// </summary>
-		internal static Dictionary<int, float> SlotsFilledPerUse;
 
 		/// <summary>
 		/// Mainly for "Counter" projectiles that count as minions but should not be teleported (by the Minion Control Rod)
@@ -71,11 +67,6 @@ namespace SummonersAssociation
 				new MinionModel(ItemID.EmpressBlade, BuffID.EmpressBlade, ProjectileID.EmpressBlade)
 			};
 
-			//TODO API extension for slot count on item, store as static because it's actually referenced via ItemModel which is created dynamically
-			SlotsFilledPerUse = new Dictionary<int, float> {
-				//[ItemID.SpiderStaff] = 0.75f //Changed to 1 in 1.4
-			};
-
 			TeleportConditionMinions = new Dictionary<int, Func<Projectile, bool>>() {
 				[ProjectileID.StormTigerGem] = ProjectileFalse,
 				[ProjectileID.AbigailCounter] = ProjectileFalse
@@ -92,7 +83,6 @@ namespace SummonersAssociation
 
 		public override void Unload() {
 			SupportedMinions = null;
-			SlotsFilledPerUse = null;
 			TeleportConditionMinions = null;
 			BookTypes = null;
 

--- a/SummonersAssociation.cs
+++ b/SummonersAssociation.cs
@@ -14,7 +14,7 @@ namespace SummonersAssociation
 	{
 		internal static List<MinionModel> SupportedMinions;
 		/// <summary>
-		/// Hardcoded special vanilla minions that summon a non-1f amount of minions on use
+		/// Special weapons that summon a non-1f amount of minions on use
 		/// </summary>
 		internal static Dictionary<int, float> SlotsFilledPerUse;
 
@@ -39,6 +39,13 @@ namespace SummonersAssociation
 		public override void Load() {
 			Instance = this;
 
+			LoadData();
+
+			string category = $"Configs.Common.";
+			AcceptClientChangesText ??= Language.GetOrRegister(this.GetLocalizationKey($"{category}AcceptClientChanges"));
+		}
+
+		private static void LoadData() {
 			SupportedMinions = new List<MinionModel>() {
 				new MinionModel(ItemID.BabyBirdStaff, BuffID.BabyBird, ProjectileID.BabyBird),
 				new MinionModel(ItemID.AbigailsFlower, BuffID.AbigailMinion, ProjectileID.AbigailCounter),
@@ -58,12 +65,13 @@ namespace SummonersAssociation
 				new MinionModel(ItemID.RavenStaff, BuffID.Ravens, ProjectileID.Raven),
 				new MinionModel(ItemID.TempestStaff, BuffID.SharknadoMinion, ProjectileID.Tempest),
 				new MinionModel(ItemID.DeadlySphereStaff, BuffID.DeadlySphere, ProjectileID.DeadlySphere),
-				new MinionModel(ItemID.StardustDragonStaff, BuffID.StardustDragonMinion, ProjectileID.StardustDragon2, 1f),
+				// StardustDragonStaff: special treatment to count the 4 summoned projectiles (2x0.5f and 2x0f slots) by only concidering the second body part as 1 minion
+				new MinionModel(ItemID.StardustDragonStaff, BuffID.StardustDragonMinion, new ProjModel(ProjectileID.StardustDragon2, 1f)),
 				new MinionModel(ItemID.StardustCellStaff, BuffID.StardustMinion, ProjectileID.StardustCellMinion),
 				new MinionModel(ItemID.EmpressBlade, BuffID.EmpressBlade, ProjectileID.EmpressBlade)
 			};
 
-			//For SlotsFilledPerUse we can't use MinionModel.GetSlotsPerProjectile because thats just a list of projectiles, and not those that are summoned once on use
+			//TODO API extension for slot count on item, store as static because it's actually referenced via ItemModel which is created dynamically
 			SlotsFilledPerUse = new Dictionary<int, float> {
 				//[ItemID.SpiderStaff] = 0.75f //Changed to 1 in 1.4
 			};
@@ -72,9 +80,6 @@ namespace SummonersAssociation
 				[ProjectileID.StormTigerGem] = ProjectileFalse,
 				[ProjectileID.AbigailCounter] = ProjectileFalse
 			};
-
-			string category = $"Configs.Common.";
-			AcceptClientChangesText ??= Language.GetOrRegister(this.GetLocalizationKey($"{category}AcceptClientChanges"));
 		}
 
 		public override void PostSetupContent()

--- a/SummonersAssociation.cs
+++ b/SummonersAssociation.cs
@@ -62,7 +62,12 @@ namespace SummonersAssociation
 				new MinionModel(ItemID.TempestStaff, BuffID.SharknadoMinion, ProjectileID.Tempest),
 				new MinionModel(ItemID.DeadlySphereStaff, BuffID.DeadlySphere, ProjectileID.DeadlySphere),
 				// StardustDragonStaff: special treatment to count the 4 summoned projectiles (2x0.5f and 2x0f slots) by only concidering the second body part as 1 minion
-				new MinionModel(ItemID.StardustDragonStaff, BuffID.StardustDragonMinion, new ProjModel(ProjectileID.StardustDragon2, 1f)),
+				new MinionModel(ItemID.StardustDragonStaff, BuffID.StardustDragonMinion, new List<ProjModel>(){
+					new ProjModel(ProjectileID.StardustDragon1, 0f),
+					new ProjModel(ProjectileID.StardustDragon2, 1f),
+					new ProjModel(ProjectileID.StardustDragon3, 0f),
+					new ProjModel(ProjectileID.StardustDragon4, 0f),
+				}),
 				new MinionModel(ItemID.StardustCellStaff, BuffID.StardustMinion, ProjectileID.StardustCellMinion),
 				new MinionModel(ItemID.EmpressBlade, BuffID.EmpressBlade, ProjectileID.EmpressBlade)
 			};

--- a/SummonersAssociationAPI.cs
+++ b/SummonersAssociationAPI.cs
@@ -61,7 +61,7 @@ namespace SummonersAssociation
 			List<int> projectileIDs = new List<int>();
 			foreach (var model in SummonersAssociation.SupportedMinions) {
 				if (model.ItemID > 0 && model.BuffID == buffType) {
-					projectileIDs = model.ProjectileIDs;
+					projectileIDs = model.ProjData.Select(d => d.ProjID).ToList();
 					break;
 				}
 			}
@@ -78,7 +78,7 @@ namespace SummonersAssociation
 			List<int> projectileIDs = new List<int>();
 			foreach (var model in SummonersAssociation.SupportedMinions) {
 				if (model.BuffID > 0 && model.ItemID == itemType) {
-					projectileIDs = model.ProjectileIDs;
+					projectileIDs = model.ProjData.Select(d => d.ProjID).ToList();
 					break;
 				}
 			}
@@ -123,7 +123,7 @@ namespace SummonersAssociation
 		/// <returns>Buff ID. 0 if projectile is not associated with a minion</returns>
 		public static int GetBuffIDAssociatedWithProjectile(int projType) {
 			foreach (var model in SummonersAssociation.SupportedMinions) {
-				if (model.BuffID > 0 && model.ProjectileIDs.Contains(projType)) {
+				if (model.BuffID > 0 && model.ContainsProjID(projType)) {
 					return model.BuffID;
 				}
 			}
@@ -138,7 +138,7 @@ namespace SummonersAssociation
 		/// <returns>Item ID. 0 if projectile is not associated with a minion</returns>
 		public static int GetItemIDAssociatedWithProjectile(int projType) {
 			foreach (var model in SummonersAssociation.SupportedMinions) {
-				if (model.ItemID > 0 && model.ProjectileIDs.Contains(projType)) {
+				if (model.ItemID > 0 && model.ContainsProjID(projType)) {
 					return model.ItemID;
 				}
 			}

--- a/SummonersAssociationSystem.cs
+++ b/SummonersAssociationSystem.cs
@@ -208,7 +208,7 @@ namespace SummonersAssociation
 						AddMinion(new MinionModel(itemID, buffID, projID));
 					}
 					else {
-						throw new Exception($"{projArg} does not have a suitable type for \"{message}\"");
+						throw new Exception($"\"{projArg}\" does not have a suitable type for \"{message}\"");
 					}
 					return "Success";
 				}

--- a/SummonersAssociationSystem.cs
+++ b/SummonersAssociationSystem.cs
@@ -121,14 +121,6 @@ namespace SummonersAssociation
 		//	    (Func<Projectile, bool>) ((Projectile p) => false) //return false here to prevent it from teleporting, otherwise, true
 		//	);
 		//
-		//	Summon weapons that occupy a non-whole number amount of minionSlots on use should use this to be compatible with loadouts.
-		//	Otherwise it will assume the value in ItemID.Sets.StaffMinionSlotsRequired (which defaults to 1)
-		//	summonersAssociation.Call(
-		//		"AddSlotsFilledPerUse",
-		//		ItemType<MinionItem>(),
-		//		0.5f
-		//	);
-		//
 		//  Get a copy of the stored information about all minions (See SummonersAssociationIntegrationExample.cs for more info)
 		//  var data = (List<Dictionary<string, object>>)summonersAssociation.Call(
 		//		"GetSupportedMinions",

--- a/SummonersAssociationSystem.cs
+++ b/SummonersAssociationSystem.cs
@@ -168,7 +168,10 @@ namespace SummonersAssociation
 						throw new Exception("Invalid buff '" + buffID + "' registered" + itemMsg);
 
 					object projArg = args[3];
-					if (projArg is List<Dictionary<string, object>> projDataDicts) {
+					if (args.Length > 3 + 1) {
+						throw new Exception($"\"{message}\" does not take more than 3 parameters");
+					}
+					else if (projArg is List<Dictionary<string, object>> projDataDicts) {
 						if (projDataDicts.Count == 0) throw new Exception("ProjModel list empty" + itemMsg);
 
 						var addedProjIDs = new HashSet<int>(); // Sanitize lists to not contain duplicates
@@ -205,8 +208,7 @@ namespace SummonersAssociation
 						AddMinion(new MinionModel(itemID, buffID, projID));
 					}
 					else {
-						//TODO should this case exist? throw exception perhaps?
-						return "Failure";
+						throw new Exception($"{projArg} does not have a suitable type for \"{message}\"");
 					}
 					return "Success";
 				}
@@ -240,9 +242,12 @@ namespace SummonersAssociation
 					var list = SummonersAssociation.SupportedMinions.Select(m => m.ConvertToDictionary(apiVersion)).ToList();
 					return list;
 				}
+				else {
+					throw new Exception($"\"{message}\" is not an accepted call");
+				}
 			}
 			catch (Exception e) {
-				logger.Error(modSA.Name + " Call Error: " + e.StackTrace + e.Message);
+				logger.Error(modSA.Name + " Call Error: " + e.StackTrace + ": " + e.Message + "\nConsult https://github.com/JavidPack/SummonersAssociation/wiki/Support-using-Mod-Call");
 			}
 			return "Failure";
 		}

--- a/SummonersAssociationSystem.cs
+++ b/SummonersAssociationSystem.cs
@@ -101,7 +101,7 @@ namespace SummonersAssociation
 		//				["Slot"] = 0.25f
 		//			},
 		//			new Dictionary<string, object>() {
-		//				["ProjID"] = ProjectileType<MinionProjectile2>(),
+		//				["ProjID"] =  ProjectileType<MinionProjectile2>(),
 		//				["Slot"] = 1f //This can be omitted aswell (then it'll default to Projectile.minionSlots), only ProjID is mandatory
 		//			}
 		//		}
@@ -111,14 +111,22 @@ namespace SummonersAssociation
 		//  Or if a minion hovers over your head and should never move
 		//	summonersAssociation.Call(
 		//		"AddTeleportConditionMinion",
-		//		ProjectileType<MinionCounterProjectile>()
+		//		 ProjectileType<MinionCounterProjectile>()
 		//	);
 		//	
 		//  Customizable condition (no condition: defaults to false):
 		//	summonersAssociation.Call(
 		//		"AddTeleportConditionMinion",
-		//	    ModContent.ProjectileType<MinionProjectile>(),
+		//	    ProjectileType<MinionProjectile>(),
 		//	    (Func<Projectile, bool>) ((Projectile p) => false) //return false here to prevent it from teleporting, otherwise, true
+		//	);
+		//
+		//	Summon weapons that occupy a non-whole number amount of minionSlots on use should use this to be compatible with loadouts.
+		//	Otherwise it will assume the value in ItemID.Sets.StaffMinionSlotsRequired (which defaults to 1)
+		//	summonersAssociation.Call(
+		//		"AddSlotsFilledPerUse",
+		//		ItemType<MinionItem>(),
+		//		0.5f
 		//	);
 		//
 		//  Get a copy of the stored information about all minions (See SummonersAssociationIntegrationExample.cs for more info)

--- a/UI/LoadoutBookUI.cs
+++ b/UI/LoadoutBookUI.cs
@@ -209,7 +209,7 @@ namespace SummonersAssociation.UI
 					#region Setup weapon tooltip
 					tooltip.Add(itemModel.Name);
 
-					if (itemModel.SlotsFilledPerUse > 1) {
+					if (itemModel.SlotsFilledPerUse != 1) {
 						tooltip.Add(UISystem.LoadoutBookSlotsRequired.Format(itemModel.SlotsFilledPerUse));
 					}
 

--- a/UISystem.cs
+++ b/UISystem.cs
@@ -165,21 +165,26 @@ namespace SummonersAssociation
 					// Check to see if this buff represents a minion or not
 					MinionModel minion = SummonersAssociation.SupportedMinions.SingleOrDefault(minionEntry => minionEntry.BuffID == buffID);
 					if (minion != null) {
-						List<int> projectileList = minion.ProjectileIDs;
+						var projData = minion.ProjData;
 
-						for (int i = 0; i < minion.ProjectileIDs.Count; i++) {
-							int num = player.ownedProjectileCounts[minion.ProjectileIDs[i]];
+						// Use lowest slot of currently summoned minions so the highest possible total minion count is shown for this buff
+						float lowestSlots = float.MaxValue;
+
+						foreach (var data in projData) {
+							int num = player.ownedProjectileCounts[data.ProjID];
 							if (num > 0) {
 								number += num;
-								slots += num * minion.Slots[i];
+								float slot = data.Slot;
+								if (slot < lowestSlots)
+									lowestSlots = slot;
+
+								slots += num * data.Slot;
 							}
 						}
-						//Projectiles spawn one tick after the buff is applied, showing 0 for a single tick if the buff is fresh
+
+						// Projectiles spawn one tick after the buff is applied, showing 0 for a single tick if the buff is fresh
 						if (number == 0) continue;
 
-						//Use lowestSlots so the highest possible minion count is shown for this buff
-						//edge case 0, if for whatever reason a mod manually assigns 0 as the slot, it will turn it to 1
-						float lowestSlots = minion.Slots.Min(x => x == 0 ? 1 : x);
 						int newMaxMinions = (int)Math.Floor(player.maxMinions / lowestSlots);
 						string ratio = MinionSlotsBuffText.Format(number, newMaxMinions);
 						// TODO: 7/8 shown for spider minions with stardust armor. Technically there is .75 slots left, but StaffMinionSlotsRequired defaults to 1 and is an int. Might need to do the math and show 1 less if available minion slots is less than 1.

--- a/UISystem.cs
+++ b/UISystem.cs
@@ -173,12 +173,17 @@ namespace SummonersAssociation
 						foreach (var data in projData) {
 							int num = player.ownedProjectileCounts[data.ProjID];
 							if (num > 0) {
-								number += num;
 								float slot = data.Slot;
-								if (slot < lowestSlots)
-									lowestSlots = slot;
+								// Checking for slots existing is required as it's a prerequisite for being concidered a minion (no MinionModel otherwise) and contributing to the minion limit
+								// Stardust Dragon has a custom model that sets all segments to 0 except one to 1, don't want it to count as 4/1 minions
+								if (slot > 0) {
+									number += num;
 
-								slots += num * data.Slot;
+									if (slot < lowestSlots)
+										lowestSlots = slot;
+
+									slots += num * data.Slot;
+								}
 							}
 						}
 

--- a/UISystem.cs
+++ b/UISystem.cs
@@ -172,18 +172,16 @@ namespace SummonersAssociation
 
 						foreach (var data in projData) {
 							int num = player.ownedProjectileCounts[data.ProjID];
-							if (num > 0) {
-								float slot = data.Slot;
+							float slot = data.Slot;
+							if (num > 0 && slot > 0) {
 								// Checking for slots existing is required as it's a prerequisite for being concidered a minion (no MinionModel otherwise) and contributing to the minion limit
 								// Stardust Dragon has a custom model that sets all segments to 0 except one to 1, don't want it to count as 4/1 minions
-								if (slot > 0) {
-									number += num;
+								number += num;
 
-									if (slot < lowestSlots)
-										lowestSlots = slot;
+								if (slot < lowestSlots)
+									lowestSlots = slot;
 
-									slots += num * data.Slot;
-								}
+								slots += num * data.Slot;
 							}
 						}
 

--- a/description.txt
+++ b/description.txt
@@ -20,6 +20,7 @@ Changelog:
 v0.5:
 * Fix missing apostrophe in "Summoners Association"
 * Fix whips appearing in the Minion Books
+* Fix Minion Books not properly counting modded weapons that summon non-whole number amount of minion slots on use (as long as the modders implement it properly)
 * Renamed (Automatic) Minion History Book to (Automatic) Minion Loadout Book
 * Updated the API. Modders will likely need to change their Mod.Call code. See the GitHub wiki for details
 

--- a/description.txt
+++ b/description.txt
@@ -21,6 +21,7 @@ v0.5:
 * Fix missing apostrophe in "Summoners Association"
 * Fix whips appearing in the Minion Books
 * Renamed (Automatic) Minion History Book to (Automatic) Minion Loadout Book
+* Updated the API. Modders will likely need to change their Mod.Call code. See the GitHub wiki for details
 
 v0.4.8.11:
 * Fix cross mod calls to this mod not working

--- a/description_workshop.txt
+++ b/description_workshop.txt
@@ -47,6 +47,7 @@ v0.5:
 * Fix missing apostrophe in "Summoners Association"
 * Fix whips appearing in the Minion Books
 * Renamed (Automatic) Minion History Book to (Automatic) Minion Loadout Book
+* Updated the API. Modders will likely need to change their Mod.Call code. See the GitHub wiki for details
 
 v0.4.8.11:
 * Fix cross mod calls to this mod not working

--- a/description_workshop.txt
+++ b/description_workshop.txt
@@ -46,6 +46,7 @@ If you experience issues with Minion Control Rods' reticle feature, let us know 
 v0.5:
 * Fix missing apostrophe in "Summoners Association"
 * Fix whips appearing in the Minion Books
+* Fix Minion Books not properly counting modded weapons that summon non-whole number amount of minion slots on use (as long as the modders implement it properly)
 * Renamed (Automatic) Minion History Book to (Automatic) Minion Loadout Book
 * Updated the API. Modders will likely need to change their Mod.Call code. See the GitHub wiki for details
 


### PR DESCRIPTION
`MinionModel` has been made more expandable by incorporating a dictionary approach to the projectile data (from the triple of item/buff/projectile(s)), which currently only includes a `Projectile.minionSlots` override, but may have more info in the future.

The resulting API changes are as follows:
* `"AddMinionInfo", int itemID, int buffID, int projectileID` stays as is

* `"AddMinionInfo", int itemID, int buffID, List<int> projectileIDs` stays as is

* `"AddMinionInfo", int itemID, int buffID, int projectileID, float slots` becomes:
`"AddMinionInfo", int itemID, int buffID, Dictionary<string, object> projModel`

* `"AddMinionInfo", int itemID, int buffID, List<int> projectileIDs, List<float> slots` becomes:
`"AddMinionInfo", int itemID, int buffID, List<Dictionary<string, object>> projData`

This change makes it so there's always 3 parameters, two calls being for registering 1 projectile, and two for more than 1 projectile, with each variant allowing a simple definition that will assume default parameters for any additional data (such as "Slot"), and an advanced definition through a dictionary.

* `"GetSupportedMinions"` return type is the same, except the underlying data previously storing `ProjectileIDs` and `Slots` is now unified into a single object of type `List<Dictionary<string, object>>` indexed via `"ProjData"`

None of these changes are made to be backwards compatible due to mods adding summons having to recompile their mods anyways due to various tml changes.

Misc:
* SlotsFilledPerUse, which was unused on 1.4 as spider minions started using 1 slot instead of 0.75, is now fully removed because TML supports partial slots via `StaffMinionSlotsRequired`. Porting notes should remark this on the wiki
* Fix a bug where if a mod registers minions with different slots to 1 buff, itll always pick the smallest slot when displaying the count instead of _only if the minion that has the smallest slot is actually summoned_.