### PR TITLE
Calamity multiple minion slots support

### DIFF
--- a/ModSupport/CalamityMod.cs
+++ b/ModSupport/CalamityMod.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+
+namespace SummonersAssociation.ModSupport
+{
+	public class CalamityMod
+	{
+        public static string Name = "CalamityMod";
+
+        public static Dictionary<string, int> MinionToSlotsMap = new Dictionary<string, int>{
+                { "Shellfish Staff", 2 },
+                { "Wither Blossoms Staff", 2 },
+                { "Entropy's Vigil", 2 },
+                { "Infected Remote", 3 },
+                { "Plantation Staff", 3 },
+                { "Resurrection Butterfly", 2 },
+                { "Ares' Exoskeleton", 3 },
+                { "Cosmic Immaterializer", 10 },
+                { "Cosmilamp", 2 },
+                { "Dragonblood Disgorger", 6 },
+                { "Endogenesis", 10 },
+                { "Flowers of Mortality", 3 },
+                { "King of Constellations, Tenryū", 4 },
+                { "Lilies of finality", 2 },
+                { "Metastasis", 4 },
+                { "Mutated Truffle", 3 },
+                { "Perdition", 5 },
+                { "Saros Possession", 8 },
+                { "Sirius", 6 },
+                { "Temporal Umbrella", 5 },
+                { "Void Concentration Staff", 3 },
+                { "Warloks' Moon Fist", 4 },
+                { "Yharon's Kindle Staff", 5 },
+            };
+	}
+}

--- a/ModSupport/CalamityMod.cs
+++ b/ModSupport/CalamityMod.cs
@@ -20,7 +20,7 @@ namespace SummonersAssociation.ModSupport
                 { "Endogenesis", 10 },
                 { "Flowers of Mortality", 3 },
                 { "King of Constellations, Tenryū", 4 },
-                { "Lilies of finality", 2 },
+                { "Lilies of Finality", 2 },
                 { "Metastasis", 4 },
                 { "Mutated Truffle", 3 },
                 { "Perdition", 5 },

--- a/Models/ItemModel.cs
+++ b/Models/ItemModel.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using SummonersAssociation.ModSupport;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
@@ -92,6 +94,14 @@ namespace SummonersAssociation.Models
 			InventoryIndex = Main.InventorySlotsTotal + i;
 			Active = false;
 		}
+
+        /// <summary>
+		/// Get amount of minion slots consumed by a summoner item in a more trustable way,
+        /// potentially supporting different mods
+		/// </summary>
+        public int GetMinionSlotsExtended() {
+            return CalamityMod.MinionToSlotsMap.GetValueOrDefault(this.Name, 1);
+        }
 
 		public override string ToString() =>
 			"Name: " + Name + "; Active: " + Active + "; Index: " + InventoryIndex + "; Count: " + SummonCount;

--- a/SummonersAssociation.csproj
+++ b/SummonersAssociation.csproj
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
+
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\tModLoader.targets" />
   <PropertyGroup>
     <AssemblyName>SummonersAssociation</AssemblyName>
-    <TargetFramework>net6.0</TargetFramework>
-    <PlatformTarget>AnyCPU</PlatformTarget>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="tModLoader.CodeAssist" Version="0.1.*" />
   </ItemGroup>
   <ItemGroup>
     <None Remove="**\*.png" />

--- a/SummonersAssociation.sln
+++ b/SummonersAssociation.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.2.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SummonersAssociation", "SummonersAssociation.csproj", "{6B82C52F-2195-72C2-4753-F5FF0922F904}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{6B82C52F-2195-72C2-4753-F5FF0922F904}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6B82C52F-2195-72C2-4753-F5FF0922F904}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6B82C52F-2195-72C2-4753-F5FF0922F904}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6B82C52F-2195-72C2-4753-F5FF0922F904}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {B90FD351-C988-4EC7-8133-DAA34F62F03C}
+	EndGlobalSection
+EndGlobal

--- a/SummonersAssociationPlayer.cs
+++ b/SummonersAssociationPlayer.cs
@@ -152,7 +152,7 @@ namespace SummonersAssociation
 									PlayerInput.ScrollWheelDelta = 0;
 									//Only allow to increase if total summon count differential is above or
 									//equal to the number of slots needed to summon
-									if (LoadoutBookUI.summonCountDelta >= highlighted.SlotsFilledPerUse) {
+									if (LoadoutBookUI.summonCountDelta >= highlighted.GetMinionSlotsExtended()) {
 										triggered = true;
 
 										highlighted.SummonCount++;

--- a/UI/LoadoutBookUI.cs
+++ b/UI/LoadoutBookUI.cs
@@ -552,8 +552,7 @@ namespace SummonersAssociation.UI
             for (int i = 0; i < itemModels.Count; i++) {
                 ItemModel itemModel = itemModels[i];
                 if (itemModel.Active) {
-                    int minionSlots = itemModel.GetMinionSlotsExtended();
-                    newSum += itemModel.SummonCount * minionSlots;
+                    newSum += itemModel.SummonCount * itemModel.GetMinionSlotsExtended();;
                 }
             }
 

--- a/UI/LoadoutBookUI.cs
+++ b/UI/LoadoutBookUI.cs
@@ -552,7 +552,7 @@ namespace SummonersAssociation.UI
             for (int i = 0; i < itemModels.Count; i++) {
                 ItemModel itemModel = itemModels[i];
                 if (itemModel.Active) {
-                    newSum += itemModel.SummonCount * itemModel.GetMinionSlotsExtended();;
+                    newSum += itemModel.SummonCount * itemModel.GetMinionSlotsExtended();
                 }
             }
 

--- a/UI/LoadoutBookUI.cs
+++ b/UI/LoadoutBookUI.cs
@@ -545,17 +545,20 @@ namespace SummonersAssociation.UI
 		/// <summary>
 		/// summonCountTotal minus all the summon counts weighted with the slots needed
 		/// </summary>
-		public static float GetSummonCountDelta() {
-			float sum = summonCountTotal;
-			float newSum = 0;
-			for (int i = 0; i < itemModels.Count; i++) {
-				ItemModel itemModel = itemModels[i];
-				if (itemModel.Active) {
-					newSum += itemModel.SummonCount * itemModel.SlotsFilledPerUse;
-				}
-			}
-			return sum - newSum;
-		}
+        public static float GetSummonCountDelta() {
+            float sum = summonCountTotal;
+            float newSum = 0;
+
+            for (int i = 0; i < itemModels.Count; i++) {
+                ItemModel itemModel = itemModels[i];
+                if (itemModel.Active) {
+                    int minionSlots = itemModel.GetMinionSlotsExtended();
+                    newSum += itemModel.SummonCount * minionSlots;
+                }
+            }
+
+            return sum - newSum;
+        }
 
 		/// <summary>
 		/// Called when the UI is about to appear


### PR DESCRIPTION
A common problem when using `Minion Loadout Book`/`Automatic Minion Loadout Book` along with calamity is that some minions use multiple minion slots. The UI is not aware of that and simulates the used/remaining slots as if every summoner item used exactly 1 slot, often bringing results that differ from the reality.

In this demonstration, you can see 2 minions being used:
- 1x Endogenesis staff (consumes 10 minion slots, 10 x 1 = 10 minion slots used in total)
- 2x Yharon's Kindle Staff (consumes 5 minion slots, 5 x 2 = 10 minion slots used in total)

Usually the mod would display 3/21 slots being used, however with this PR it correctly displays 20/21 slots being used, synced with the Summoner UI output.

| Before | After |
| :- | :- |
| ![image](https://github.com/user-attachments/assets/945256ba-acc9-46a7-9368-5c6eb9255ac9) | ![image](https://github.com/user-attachments/assets/c8033c31-d13f-4d41-8649-bca1afd13426) |